### PR TITLE
Fix CallbackFactory semicolon

### DIFF
--- a/CallbackFactory.cs
+++ b/CallbackFactory.cs
@@ -63,7 +63,6 @@ public class CallbackFactory {
         if (callbackCache.TryGetValue(callbackId, out var callback)) {
             if (callback.onCallback is not null) {
                 Task.Run(() => callback.onCallback(callbackQueryId, messageId, chatId));
-                ;
             }
             return true;
         }


### PR DESCRIPTION
## Summary
- remove stray semicolon after `Task.Run` in `InvokeAsync`

## Testing
- `dotnet build Telegram.Bot.UI.sln -clp:ErrorsOnly` *(fails: command not found)*